### PR TITLE
ci: remove pipeline library declaration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,3 @@
-@Library('syndesis-pipeline-library@master')
-
 def username = System.getenv().get('GITHUB_USERNAME')
 def password = System.getenv().get('GITHUB_PASSWORD')
 def openshiftMaster = System.getenv().get('OPENSHIFT_MASTER')


### PR DESCRIPTION
This declaration is not need anymore as we have pipeline declared in job itself.