### PR TITLE
[webdriver] Run webdriver manager update automagically

### DIFF
--- a/e2e-xvfb.sh
+++ b/e2e-xvfb.sh
@@ -3,5 +3,4 @@
 nohup /usr/bin/Xvfb :99 -ac -screen 0 1280x720x24 &
 export DISPLAY=:99
 yarn --no-progress
-yarn webdriver-manager update
 exec yarn e2e:syndesis-qe

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:xvfb": "docker run --rm -v `pwd`:/syndesis-ui:z -w /syndesis-ui -u `id -u` docker.io/syndesis/karma-xvfb ./karma-xvfb.sh",
     "pree2e": "webdriver-manager update",
     "e2e": "better-npm-run e2e:local",
+    "pree2e:syndesis-qe": "webdriver-manager update",
     "e2e:syndesis-qe": "better-npm-run e2e:syndesis-qe",
     "e2e:xvfb": "docker run -e SYNDESIS_UI_URL=$SYNDESIS_UI_URL --rm -v `pwd`:/syndesis-ui:z -w /syndesis-ui -u `id -u` docker.io/syndesis/karma-xvfb ./e2e-xvfb.sh"
   },


### PR DESCRIPTION
webdriver update should be run automatically this way
```bash
$ yarn e2e:syndesis-qe -- --cucumberOpts.tags="@datamapper" 
yarn e2e:syndesis-qe v0.24.6
$ webdriver-manager update
[15:21:06] I/update - chromedriver: file exists /home/jludvice/devel/redhat/ipaas/syndesis-e2e-tests/node_modules/protractor/node_modules/webdriver-manager/selenium/chromedriver_2.30.zip
[15:21:06] I/update - chromedriver: unzipping chromedriver_2.30.zip
[15:21:06] I/update - chromedriver: setting permissions to 0755 for /home/jludvice/devel/redhat/ipaas/syndesis-e2e-tests/node_modules/protractor/node_modules/webdriver-manager/selenium/chromedriver_2.30
[15:21:06] I/update - chromedriver: chromedriver_2.30 up to date
[15:21:06] I/update - selenium standalone: file exists /home/jludvice/devel/redhat/ipaas/syndesis-e2e-tests/node_modules/protractor/node_modules/webdriver-manager/selenium/selenium-server-standalone-3.4.0.jar
[15:21:06] I/update - selenium standalone: selenium-server-standalone-3.4.0.jar up to date
(node:10604) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: response status code is not 200
$ better-npm-run e2e:syndesis-qe --cucumberOpts.tags=@datamapper
running better-npm-run in /home/jludvice/devel/redhat/ipaas/syndesis-e2e-tests
Executing script: e2e:syndesis-qe

to be executed: protractor --cucumberOpts.tags=@datamapper
Using syndesis ui on url https://syndesis-qe.b6ff.rh-idev.openshiftapps.com/
[15:21:07] I/launcher - Running 1 instances of WebDriver
[15:21:07] I/direct - Using ChromeDriver directly...
[15:21:08] W/runner - Ignoring unknown extra flags: cucumberOpts. This will be an error in future versions, please use --disableChecks flag to disable the  Protractor CLI flag checks. 
```