### PR TITLE
chore: Add protractor-console-plugin to catch browser logs

### DIFF
--- a/e2e/conf/protractor.base.conf.js
+++ b/e2e/conf/protractor.base.conf.js
@@ -28,6 +28,13 @@ exports.config = {
   baseUrl: 'http://localhost:4200/',
   framework: 'custom',
   frameworkPath: require.resolve('protractor-cucumber-framework'),
+  plugins: [{
+    package: 'protractor-console-plugin',
+    failOnWarning: false,
+    failOnError: false,
+    logWarnings: true,
+    exclude: {}
+  }],
   cucumberOpts: {
     require: [
       testPath + '/env.ts',

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "fs-extra": "^2.0.0",
     "ncp": "^2.0.0",
     "protractor": "5.1.1",
+    "protractor-console-plugin": "^0.1.1",
     "protractor-cucumber-framework": "^0.6.0",
     "ts-node": "2.1.0",
     "tslint": "^4.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3726,6 +3726,12 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+protractor-console-plugin@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/protractor-console-plugin/-/protractor-console-plugin-0.1.1.tgz#749da95b0695dede43b50fef3faf9f0b62a47c96"
+  dependencies:
+    q "^1.4.1"
+
 protractor-cucumber-framework@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/protractor-cucumber-framework/-/protractor-cucumber-framework-0.6.0.tgz#d1259c7836f5ead010df341c0f6de48b640b7c47"


### PR DESCRIPTION
This PR resolves #26.

`protractor-console-plugin` should provide simple mechanism how error and warning logs are reported back during E2E tests. It should be sufficient for now and we can upgrade to asserting browser logs later.