### PR TITLE
chore(build): Discard old builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,7 @@
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '5'))
+])
+
 def namespace = System.getenv().get('E2E_NAMESPACE')
 
 node {


### PR DESCRIPTION
This keeps at most 5 builds/artifacts in order to preserve disk space on
Jenkins.