### PR TITLE
[closes #34] Implement basic test for oauth settings page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ or specify `export SYNDESIS_TEST_CONFIG=/path/to/test_config.json`
         "email": "camilla@gmail.com",
         "firstName": "Camilla",
         "lastName": "Syndesio"
-
+      }
     }
   },
   "connection": {
@@ -40,6 +40,12 @@ or specify `export SYNDESIS_TEST_CONFIG=/path/to/test_config.json`
       "userName": "YOUR_SECRET_DATA"
     },
     "Twitter" : "..."
+  },
+  "settings": {
+    "Twitter": {
+      "clientId": "aaaaaaj to je ID",
+      "clientSecret": "aaa to je seeecret"
+    }
   }
 }
 ```

--- a/e2e/settings/settings.feature
+++ b/e2e/settings/settings.feature
@@ -1,0 +1,15 @@
+@settings
+Feature: Set oauth app credentials
+
+
+  Scenario: Set twitter oauth app settings
+    Given clean application state
+    When "Camilla" navigates to the "Settings" page
+    Then "Camilla" is presented with "OAuth Client Management" settings tab
+    And settings item "Salesforce" has button "Register"
+    And settings item "Twitter" has button "Register"
+
+    When "Camilla" clicks to the "Twitter" item "Register" button
+    And fill form in "Twitter" settings item
+    And "Camilla" clicks to the "Twitter" item "Save" button
+    Then settings item "Twitter" must have alert with text "Registration Successful!"

--- a/e2e/settings/settings.po.ts
+++ b/e2e/settings/settings.po.ts
@@ -1,0 +1,97 @@
+import {SyndesisComponent} from '../common/common';
+import {$, by, ElementArrayFinder, ElementFinder} from 'protractor';
+import {P} from '../common/world';
+import {log} from '../../src/app/logging';
+
+export class SettingsPage implements SyndesisComponent {
+  rootElement(): ElementFinder {
+    return $('syndesis-settings-root');
+  }
+
+  /**
+   * Get title of active settings tab
+   * @returns {Promise<string>} title of active settings tab
+   */
+  async activeTab(): P<string> {
+    const activeTab = this.rootElement().$('ul.nav-tabs li.active a');
+    return activeTab.getText();
+  }
+
+  /**
+   * Support method for finding settings items by name
+   * @param {ElementFinder} parent search child elements of this element
+   * @returns {ElementArrayFinder} found elements
+   */
+  listSettingsItems(parent: ElementFinder = this.rootElement()): ElementArrayFinder {
+    return parent
+      .$('pfng-list')
+      .$$('div.list-pf-item');
+  }
+
+  /**
+   * Fetch all settings items and find proper one according to given name.
+   * @param {string} name name of settings item
+   * @returns {Promise<ElementFinder | any>} return element or reject promise
+   */
+  async getSettingsItem(name: string): P<ElementFinder | any> {
+    const items = await this.listSettingsItems();
+    log.info(`searching for ${name} in ${items.length} items`);
+
+    for (const item of items) {
+      const title = await item.$('div.list-pf-title').getText();
+      if (title === name) {
+        return item;
+      }
+    }
+    return P.reject(`item ${name} not found`);
+  }
+
+  /**
+   * Click on button which is child element of given settings item
+   * @param {string} settingsItemName name of settings item
+   * @param {string} buttonTitle title of button
+   * @returns {Promise<any>} resolved once clicked
+   */
+  async clickButton(settingsItemName: string, buttonTitle: string): P<any> {
+    const item: ElementFinder = await this.getSettingsItem(settingsItemName);
+    log.info(`click ${buttonTitle} on ${settingsItemName}`);
+    return item.element(by.buttonText(buttonTitle)).click();
+  }
+}
+
+
+/**
+ * Represents oauth apps tab.
+ */
+export class OAuthSettingsComponent extends SettingsPage {
+  rootElement(): ElementFinder {
+    return super.rootElement().$('syndesis-oauth-apps');
+  }
+
+  /**
+   *
+   * @param {string} itemTitle title of settings entry
+   * @param formData object where key is name of input field and value it's content
+   * @returns {Promise<any>} resolved when all fields are finished
+   */
+  async fillSettingsItemForm(itemTitle: string, formData: any): P<any> {
+    log.info(`filling ${itemTitle} with data '${JSON.stringify(formData)}'`);
+    const item: ElementFinder = await this.getSettingsItem(itemTitle);
+    const promises = [];
+    for (const key of Object.keys(formData)) {
+      const input = item.$(`input[name="${key}"]`);
+      promises.push(input.sendKeys(formData[key]));
+    }
+    return P.all(promises);
+  }
+
+  /**
+   * Alert should be within the settings item
+   * @param {string} itemTitle title of settings item (like Twitter)
+   * @returns {Promise<string>} string content of alert
+   */
+  async getAlertText(itemTitle: string): P<string> {
+    const item: ElementFinder = await this.getSettingsItem(itemTitle);
+    return item.$('div.alert').getText();
+  }
+}

--- a/e2e/settings/settings.steps.ts
+++ b/e2e/settings/settings.steps.ts
@@ -1,0 +1,49 @@
+import {binding, then, when} from 'cucumber-tsflow';
+import {World, P, expect} from '../common/world';
+import {OAuthSettingsComponent, SettingsPage} from './settings.po';
+
+@binding([World])
+class SettingsSteps {
+  constructor(protected world: World) {
+  }
+
+  @then(/^"([^"]*)" is presented with "([^"]*)" settings tab$/)
+  public activeTab(user: string, tabName: string): P<any> {
+
+    const page = new SettingsPage();
+    const activeTab = page.activeTab();
+
+    return expect(activeTab)
+      .to.eventually.be.equal(tabName, `Default settings tab should be ${tabName}`);
+  }
+
+  @then(/^settings item "([^"]*)" has button "([^"]*)"$/)
+  public settingsItemHasButton(itemTitle: string, buttonTitle: string): P<any> {
+    const page = new SettingsPage();
+
+    return page.getSettingsItem(itemTitle);
+  }
+
+  @when(/^"([^"]*)" clicks to the "([^"]*)" item "([^"]*)" button$/)
+  public clickSettingsButton(userAlias: string, itemTitle: string, buttonTitle: string): P<any> {
+    const page = new SettingsPage();
+    return page.clickButton(itemTitle, buttonTitle);
+  }
+
+  @when(/^fill form in "([^"]*)" settings item$/)
+  public fillSettingsItemForm(itemTitle: string): P<any> {
+    const settings = new OAuthSettingsComponent();
+    const toFill = this.world.testConfig.settings[itemTitle];
+    return settings.fillSettingsItemForm(itemTitle, toFill);
+  }
+
+  @then(/^settings item "([^"]*)" must have alert with text "([^"]*)"$/)
+  public assertSettingsAlertText(itemTitle: string, alertText: string): P<any> {
+    const settings = new OAuthSettingsComponent();
+    return expect(settings.getAlertText(itemTitle))
+      .to.eventually.contain(alertText);
+  }
+}
+
+
+export = SettingsSteps;


### PR DESCRIPTION
@mmelko @lvydra @dsimansk 

This is very basic test for settings page.
I didn't do deleting of settings as it throws HTTP500 (reported as syndesis-rest/issues#549)
and it wasn't clear how it was supposed to work.
Delete settings is TODO for future